### PR TITLE
Document the `skip` keyword argument of `@testitem`

### DIFF
--- a/src/TestItems.jl
+++ b/src/TestItems.jl
@@ -21,6 +21,12 @@ to share setup code between test items.
   before running the test code. Defaults to `true`.
 - `setup::Vector{Symbol}`: Names of `@testmodule` or `@testsnippet` definitions to
   evaluate before the test item runs.
+- `skip`: Either a `Bool` literal, or an arbitrary expression that evaluates to a `Bool`.
+  When it is `true` the test item is not run and is reported as skipped. Defaults to
+  `false`. An expression is evaluated **in the test process**, immediately before the
+  test item would have run, so checks like `VERSION < v"1.11"` or `Sys.iswindows()` see
+  the environment of the process the tests actually run in, not the one that discovered
+  them.
 
 ## Examples
 
@@ -37,6 +43,14 @@ end
 @testitem "with setup" tags=[:integration] setup=[DatabaseHelper] begin
     db = DatabaseHelper.connect()
     @test isopen(db)
+end
+
+@testitem "not ready yet" skip=true begin
+    @test false
+end
+
+@testitem "needs a recent Julia" skip=(VERSION < v"1.11") begin
+    @test true
 end
 ```
 """


### PR DESCRIPTION
Part of stream **S1 (Discovery)** of the ReTestItems feature-delta plan — A.10 item 5, *"`skip` as an item kwarg"*.

## What

Documents `skip` in the `@testitem` docstring, and adds two examples. The macro itself stays a no-op marker; nothing executable changes in this repo.

Semantics documented:

- `skip` accepts a `Bool` literal or an arbitrary expression evaluating to a `Bool`.
- An expression is evaluated **in the test process**, immediately before the test item would have run. That is the whole point of making `skip` an item keyword rather than a coordinator-side filter: `VERSION < v"1.11"` and `Sys.iswindows()` must see the *worker's* environment, not the environment that discovered the item (we support `--julia-cmd` pointing anywhere, and CI matrices routinely run several Julia versions).
- Defaults to `false`.

## Companion PRs (land in this order)

1. **this PR** — TestItems.jl: docstring.
2. TestItemDetection.jl — parse `skip` in `find_test_detail!`, return `option_skip`.
3. JuliaWorkspaces.jl — carry `option_skip` on `TestItemDetail`, plus stable test item ids.

Execution of `skip` (TestItemControllers / TestItemApp) is a later wave.

## Testing

`Pkg.test()` green (4/4). No test items exercise the docstring; behaviour is tested in TestItemDetection.jl and JuliaWorkspaces.jl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)